### PR TITLE
Migrate from greymass/eosio to wharfkit/antelope

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
         "prepare": "make"
     },
     "dependencies": {
+        "@greymass/antelope-key-encryption": "^1.3.0",
         "@greymass/base2048": "^1.0.0",
-        "@greymass/eosio": "^0.6.0",
-        "eosio-key-encryption": "^1.2.0",
-        "eosio-signing-request": "^2.5.0",
+        "@wharfkit/antelope": "^1.0.7",
+        "@wharfkit/signing-request": "^3.2.0",
         "tslib": "^2.1.0"
     },
     "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {ProgressCallback} from 'eosio-key-encryption'
+import {ProgressCallback} from '@greymass/antelope-key-encryption'
 import {GenerationArguments, KeyCertificate, KeyCertificateType} from './key-certificate'
 
 export async function generate(args: GenerationArguments, progress?: ProgressCallback) {

--- a/src/key-certificate.ts
+++ b/src/key-certificate.ts
@@ -3,8 +3,8 @@ import {
     EncryptedPrivateKeyType,
     ProgressCallback,
     SecurityLevelType,
-} from 'eosio-key-encryption'
-import {Base64u, ChainId, ChainIdType} from 'eosio-signing-request'
+} from '@greymass/antelope-key-encryption'
+import {Base64u, ChainId, ChainIdType} from '@wharfkit/signing-request'
 import {
     Checksum256,
     isInstanceOf,
@@ -15,7 +15,7 @@ import {
     Serializer,
     Struct,
     UInt32,
-} from '@greymass/eosio'
+} from '@wharfkit/antelope'
 
 import mnemonic, {wordlist} from './mnemonic'
 import PRNG from './prng'

--- a/yarn.lock
+++ b/yarn.lock
@@ -212,23 +212,23 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@greymass/antelope-key-encryption@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@greymass/antelope-key-encryption/-/antelope-key-encryption-1.3.0.tgz#ec16943ded0609e3d04ec931e9ba126f5a357c13"
+  integrity sha512-OdYrBkHHiQFDnBifv0RFs5ypyS0e42x39mIcR8Y3CauVWv+IFokwhH6vLNeayVLPyxOLwRNcPBbALgVw7rl0/Q==
+  dependencies:
+    "@greymass/miniaes" "^1.0.0"
+    "@wharfkit/antelope" "^1.0.7"
+    asmcrypto.js "^2.3.2"
+    scrypt-js "^3.0.1"
+    tslib "^2.1.0"
+
 "@greymass/base2048@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@greymass/base2048/-/base2048-1.0.0.tgz#592437ee72afe2548f97c036fe3963bfc00f192e"
   integrity sha512-Y0GmKgIu00sfskYTAEG1xG8Fvaa6pBMJw6ozhkCPa0K4Hi9rSpF+QYXuEVgia5S/bl31FxTt5hlFVApQlhGhRA==
   dependencies:
     tslib "^2.1.0"
-
-"@greymass/eosio@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@greymass/eosio/-/eosio-0.6.0.tgz#6da636c1651626881cee0a46747559d20412f3a0"
-  integrity sha512-acVKfiuNMkZ9aOFf/EJIk8X5PAoc53ZJeGP0ehpACX3Pz/rFOTmZFDnVaBKTuL3pFSMPA1K5h1la9nC42fDTcw==
-  dependencies:
-    bn.js "^4.11.9"
-    brorand "^1.1.0"
-    elliptic "^6.5.4"
-    hash.js "^1.0.0"
-    tslib "^2.0.3"
 
 "@greymass/miniaes@^1.0.0":
   version "1.0.0"
@@ -460,6 +460,26 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
+
+"@wharfkit/antelope@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@wharfkit/antelope/-/antelope-1.0.7.tgz#5ca010db963e061b2e8c47c14e55f86817718c2e"
+  integrity sha512-C4DRC4U+qC2XQKUgwznKX6i8xdKo+ZqxkZURrPTtY3v53IvKwj+3amTQQSpuECechS5x6ItcT+/fOFBNlQ2Juw==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    elliptic "^6.5.4"
+    hash.js "^1.0.0"
+    pako "^2.1.0"
+    tslib "^2.0.3"
+
+"@wharfkit/signing-request@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@wharfkit/signing-request/-/signing-request-3.2.0.tgz#94cab97e27d1001973771056cfb9d54c02e45354"
+  integrity sha512-rIMzqwAKA5vb09+1BI+9fUXbj73JIkYcD1XT/Tom+k/+bqi51JcmC0trjCOjTUOK9UYDabpxYFixrf1ZvQymKw==
+  dependencies:
+    "@wharfkit/antelope" "^1.0.7"
+    tslib "^2.0.3"
 
 acorn-jsx@^5.3.1:
   version "5.3.2"
@@ -905,25 +925,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-eosio-key-encryption@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/eosio-key-encryption/-/eosio-key-encryption-1.2.0.tgz#3593fd775314768043fd9dae18962211c9e7aede"
-  integrity sha512-RGpAVgSbQbUMDqrDNAXd3h4aU81qNJJSZX2YeNEvIqiJz06TME5VQyYDzm8sL1MbJNt0u9BMS8pv/T8sxdAAvA==
-  dependencies:
-    "@greymass/eosio" "^0.6.0"
-    "@greymass/miniaes" "^1.0.0"
-    asmcrypto.js "^2.3.2"
-    scrypt-js "^3.0.1"
-    tslib "^2.1.0"
-
-eosio-signing-request@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/eosio-signing-request/-/eosio-signing-request-2.5.0.tgz#d371f10f9cf030bc4fc3abeeb6c8432bdbb7e268"
-  integrity sha512-wS/ju5680dp28XMyKSYdDFUt3HVlaAIfHn5MlfKuf1bTluJWYgRxbToDj3x/VdhJFuw+JF/XUoL8WGEixx7JWg==
-  dependencies:
-    "@greymass/eosio" "^0.6.0"
-    tslib "^2.0.3"
 
 es-abstract@^1.18.5, es-abstract@^1.19.5:
   version "1.19.5"
@@ -2126,6 +2127,11 @@ package-hash@^4.0.0:
     hasha "^5.0.0"
     lodash.flattendeep "^4.4.0"
     release-zalgo "^1.0.0"
+
+pako@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
+  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
 parent-module@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
also handled eosio-key-encryption and eosio-signing-request, which made the move too.